### PR TITLE
Implement API endpoints for vocab cards

### DIFF
--- a/vocabcart_project/api/add_word.php
+++ b/vocabcart_project/api/add_word.php
@@ -1,3 +1,39 @@
 <?php
-// API to add a word
+// API endpoint to add a vocabulary card
+
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+require_once __DIR__ . '/../includes/config.php';
+require_once __DIR__ . '/../includes/functions.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['status' => 'error', 'message' => 'Method not allowed']);
+    exit;
+}
+
+require_login_json();
+
+$set_id = isset($_POST['set_id']) ? (int)$_POST['set_id'] : 0;
+$term = trim($_POST['term'] ?? '');
+$definition = trim($_POST['definition'] ?? '');
+
+if ($set_id <= 0 || $term === '' || $definition === '') {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Missing parameters']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare(
+        'INSERT INTO cards (set_id, term, definition, user_id) VALUES (?, ?, ?, ?)'
+    );
+    $stmt->execute([$set_id, $term, $definition, $_SESSION['user_id']]);
+
+    echo json_encode(['status' => 'success', 'id' => $pdo->lastInsertId()]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Database error']);
+}
 ?>

--- a/vocabcart_project/api/get_words.php
+++ b/vocabcart_project/api/get_words.php
@@ -1,3 +1,29 @@
 <?php
-// API to get words
+// API endpoint to retrieve cards for a vocabulary set
+
+session_start();
+header('Content-Type: application/json; charset=utf-8');
+
+require_once __DIR__ . '/../includes/config.php';
+require_once __DIR__ . '/../includes/functions.php';
+
+require_login_json();
+
+$set_id = $_GET['set_id'] ?? $_POST['set_id'] ?? null;
+
+if (!$set_id) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Missing set_id']);
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare('SELECT id, term, definition FROM cards WHERE set_id = ? ORDER BY id');
+    $stmt->execute([$set_id]);
+    $cards = $stmt->fetchAll();
+    echo json_encode(['status' => 'success', 'data' => $cards]);
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['status' => 'error', 'message' => 'Database error']);
+}
 ?>

--- a/vocabcart_project/includes/config.php
+++ b/vocabcart_project/includes/config.php
@@ -1,3 +1,21 @@
 <?php
-// Database config
+// Simple PDO database connection used by the API scripts
+
+$dsn = 'mysql:host=localhost;dbname=vocabcart;charset=utf8mb4';
+$db_user = 'root';
+$db_pass = '';
+
+try {
+    $pdo = new PDO(
+        $dsn,
+        $db_user,
+        $db_pass,
+        [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ]
+    );
+} catch (PDOException $e) {
+    die('DB connection failed');
+}
 ?>

--- a/vocabcart_project/includes/functions.php
+++ b/vocabcart_project/includes/functions.php
@@ -1,3 +1,19 @@
 <?php
-// Common functions
+// Common helper functions
+
+/**
+ * Ensure the user is logged in for JSON API endpoints.
+ * Outputs a JSON error and exits when the user is not authenticated.
+ */
+function require_login_json(): void
+{
+    if (empty($_SESSION['user_id'])) {
+        http_response_code(403);
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'Authentication required'
+        ]);
+        exit;
+    }
+}
 ?>


### PR DESCRIPTION
## Summary
- connect to the database with PDO in `config.php`
- add `require_login_json` helper for API authentication
- create `add_word.php` to insert cards
- create `get_words.php` to fetch cards by set id

## Testing
- `php -l vocabcart_project/api/add_word.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc61535808325a89e6aa4fab4712d